### PR TITLE
Fix missing attribute and sequence order

### DIFF
--- a/src/ArrayType/ArrayOfTransitionsType.php
+++ b/src/ArrayType/ArrayOfTransitionsType.php
@@ -50,4 +50,13 @@ class ArrayOfTransitionsType extends ArrayType
      * @var \jamesiarmes\PhpEws\Type\RecurringDayTransitionType[]
      */
     public $RecurringDayTransition = array();
+
+    /**
+     * A time zone transition.
+     *
+     * @since Exchange 2010
+     *
+     * @var \jamesiarmes\PhpEws\Type\TransitionType[]
+     */
+    public $Transition = array();
 }

--- a/src/assets/types.xsd
+++ b/src/assets/types.xsd
@@ -4716,10 +4716,10 @@
 
     <xs:complexType name="ArrayOfTransitionsType">
         <xs:sequence>
+            <xs:element ref="t:Transition" minOccurs="0" maxOccurs="unbounded" />
             <xs:element ref="t:AbsoluteDateTransition" minOccurs="0" maxOccurs="unbounded" />
             <xs:element ref="t:RecurringDayTransition" minOccurs="0" maxOccurs="unbounded" />
             <xs:element ref="t:RecurringDateTransition" minOccurs="0" maxOccurs="unbounded" />
-            <xs:element ref="t:Transition" minOccurs="0" maxOccurs="unbounded" />
         </xs:sequence>
         <xs:attribute name="Id" type="xs:string"/>
     </xs:complexType>


### PR DESCRIPTION
Fix pour 2 erreurs de la librairie:

- [x] Ordre des éléments pour la séquence `ArrayOfTransitionsType`
- [x] Attribut manquant `Transition` pour le type `ArrayOfTransitionsType`