### PR TITLE
Fix type for UpdateItemType::ItemChanges

### DIFF
--- a/src/Request/UpdateItemType.php
+++ b/src/Request/UpdateItemType.php
@@ -31,7 +31,7 @@ class UpdateItemType extends BaseRequestType
      *
      * @since Exchange 2007
      *
-     * @var \jamesiarmes\PhpEws\ArrayType\NonEmptyArrayOfItemChangesType[]
+     * @var \jamesiarmes\PhpEws\ArrayType\NonEmptyArrayOfItemChangesType
      */
     public $ItemChanges;
 


### PR DESCRIPTION
`ItemChanges` est bien un `NonEmptyArrayOfItemChangesType` et non un array de ce type.

https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/itemchanges