### PR TITLE
Fix type for ReferenceItemId property on ResponseObjects

### DIFF
--- a/src/Type/ResponseObjectType.php
+++ b/src/Type/ResponseObjectType.php
@@ -17,7 +17,7 @@ abstract class ResponseObjectType extends ResponseObjectCoreType
      *
      * @since Exchange 2007
      *
-     * @var string
+     * @var \jamesiarmes\PhpEws\Type\ItemIdType
      */
     public $ReferenceItemId;
 }


### PR DESCRIPTION
Est un `ItemIdType`:
https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/referenceitemid